### PR TITLE
Add robot fleet management roadmap to paperswiki KnowledgeBase

### DIFF
--- a/paperswiki/KnowledgeBase.md
+++ b/paperswiki/KnowledgeBase.md
@@ -1,0 +1,71 @@
+# Robot Fleet Management Research & Development Roadmap
+
+## Objective
+
+Develop a scalable robot fleet management platform that combines:
+
+- Discrete-event simulation (DES)
+- Production control theory
+- Multi-robot coordination
+- Stochastic optimization
+- Safety-critical control
+- Digital twin capabilities
+
+The long-term goal is to build a decision-making layer for large-scale robotic fleets operating under uncertainty.
+
+---
+
+## Architecture
+
+```text
++--------------------------------------------------+
+| Production Control Layer                         |
+|--------------------------------------------------|
+| CONWIP                                           |
+| Theory of Constraints                            |
+| Fleet Dispatch                                   |
+| Charging Policies                                |
+| Safety Constraints                               |
+| Diffusion Forecasting                            |
++--------------------------------------------------+
+                      |
+                      v
++--------------------------------------------------+
+| Fleet Management Layer                           |
+|--------------------------------------------------|
+| Task Allocation                                  |
+| Multi-Robot Scheduling                           |
+| Congestion Management                            |
+| Deadlock Recovery                                |
+| Resource Arbitration                             |
++--------------------------------------------------+
+                      |
+                      v
++--------------------------------------------------+
+| Robot Middleware Layer                           |
+|--------------------------------------------------|
+| ROS2                                             |
+| Open-RMF                                         |
++--------------------------------------------------+
+                      |
+                      v
++--------------------------------------------------+
+| Simulation Layer                                 |
+|--------------------------------------------------|
+| Gazebo                                            |
+| Isaac Sim (optional)                             |
++--------------------------------------------------+
+                      ^
+                      |
++--------------------------------------------------+
+| Discrete Event Simulation Layer                  |
+|--------------------------------------------------|
+| SimPy                                            |
+| Queueing Models                                  |
+| Workstations                                     |
+| WIP Dynamics                                     |
+| Job Arrivals                                     |
++--------------------------------------------------+
+```
+
+Source: [robotsorcerer/PapersWiki](https://github.com/robotsorcerer/PapersWiki)


### PR DESCRIPTION
## Summary
- Adds `paperswiki/KnowledgeBase.md` with the Robot Fleet Management Research & Development Roadmap (objective, architecture layers: production control, fleet management, robot middleware, simulation, discrete-event simulation)
- Links back to the source repo, [robotsorcerer/PapersWiki](https://github.com/robotsorcerer/PapersWiki)

## Note
This session is scoped only to `robotsorcerer/robotsorcerer.github.io`, so the document was created here rather than in the separate PapersWiki repo referenced in the request.

## Test plan
- [x] Rendered markdown checked locally for formatting (headings, code block, link)
- [ ] Confirm this is the intended location, or move the content into the PapersWiki repo if preferred


---
_Generated by [Claude Code](https://claude.ai/code/session_018XeDawfDk5aNENjWisL2mg)_